### PR TITLE
encode unicode text in footnotes

### DIFF
--- a/lib/PHPRtfLite/Footnote.php
+++ b/lib/PHPRtfLite/Footnote.php
@@ -261,7 +261,7 @@ class PHPRtfLite_Footnote
         }
 
         $stream->write('{\up6\chftn}' . "\r\n"
-                     . PHPRtfLite::quoteRtfCode($this->_text)
+                     . PHPRtfLite_Utf8::getUnicodeEntities(PHPRtfLite::quoteRtfCode($this->_text))
                      . '} ');
     }
 


### PR DESCRIPTION
Accents and other unicode characters in footnotes are not encoded, and thus appear garbled in Word and other editors. This encodes the text to make sure they are displayed correctly.
