### PR TITLE
encode unicode text in footnotes

### DIFF
--- a/lib/PHPRtfLite/Footnote.php
+++ b/lib/PHPRtfLite/Footnote.php
@@ -261,7 +261,7 @@ class PHPRtfLite_Footnote
         }
 
         $stream->write('{\up6\chftn}' . "\r\n"
-                     . PHPRtfLite::quoteRtfCode($this->_text)
+                     . PHPRtfLite_Utf8::getUnicodeEntities(PHPRtfLite::quoteRtfCode($this->_text), $this->_charset)
                      . '} ');
     }
 


### PR DESCRIPTION
Adding accented characters or unicode in the footnotes was not being encoded, making the text appear garbled in Word or other editors.
