### PR TITLE
PHP 7.2 compatibility fix on Table class

### DIFF
--- a/lib/PHPRtfLite/Table.php
+++ b/lib/PHPRtfLite/Table.php
@@ -49,13 +49,13 @@ class PHPRtfLite_Table implements PHPRtfLite_Freeable
      * array of PHPRtfLite_Table_Row instances
      * @var PHPRtfLite_Table_Row[]
      */
-    protected $_rows;
+    protected $_rows = [];
 
     /**
      * array of PHPRtfLite_Table_Column instances
      * @var PHPRtfLite_Table_Column[]
      */
-    protected $_columns;
+    protected $_columns = [];
 
     /**
      * @var string


### PR DESCRIPTION
With PHP 7.2 you cannot use count() on a null variable.
This class generates the following warning on line 817 and 839: "Warning: count(): Parameter must be an array or an object that implements Countable "
  