### PR TITLE
Correct the Warning: count() error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-    "name": "phprtflite/PHP7",
+    "name": "phprtflite/phprtflite",
     "description": "PHPRtfLite is an API enabling developers to create rtf documents with php.",
     "version": "dev",
     "license": "GPL-3.0",
     "authors": [
         {
-            "name": "Quentin Lacour",
-            "email": "q.lacour@gmail.com"
+            "name": "Steffen Zeidler",
+            "email": "sigma_z@sigma-scripts.de"
         }
     ],
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-    "name": "phprtflite/phprtflite",
+    "name": "phprtflite/PHP7",
     "description": "PHPRtfLite is an API enabling developers to create rtf documents with php.",
     "version": "dev",
     "license": "GPL-3.0",
     "authors": [
         {
-            "name": "Steffen Zeidler",
-            "email": "sigma_z@sigma-scripts.de"
+            "name": "Quentin Lacour",
+            "email": "q.lacour@gmail.com"
         }
     ],
     "minimum-stability": "stable",

--- a/lib/PHPRtfLite/Table.php
+++ b/lib/PHPRtfLite/Table.php
@@ -814,7 +814,7 @@ class PHPRtfLite_Table implements PHPRtfLite_Freeable
      */
     public function getRowsCount()
     {
-        return count($this->_rows);
+        return $this->_rows === null ? 0 : count($this->_rows);
     }
 
 
@@ -836,7 +836,7 @@ class PHPRtfLite_Table implements PHPRtfLite_Freeable
      */
     public function getColumnsCount()
     {
-        return count($this->_columns);
+        return $this->_columns === null ? 0 : count($this->_columns);
     }
 
 


### PR DESCRIPTION
Hi, 

I've encountered the warning: count() error when i was generating word file on an old Symfo app i'm upgrading. I've found that it was due to getColumnCount() and getRowsCount() methods so i make this fix. 

Hope it helps. 
Quentin